### PR TITLE
Add labels dictionary for bookshelves

### DIFF
--- a/components/Labels.tsx
+++ b/components/Labels.tsx
@@ -6,10 +6,14 @@ import { usePathname } from 'next/navigation'
 
 export default function Labels({
   items,
-  pathPrefix
+  pathPrefix,
+  dictionary
 }: {
   items: [string] | { _: number }
-  pathPrefix
+  pathPrefix: string,
+  dictionary: {
+    _: string
+  }
 }) {
   const path = usePathname()
 
@@ -18,7 +22,7 @@ export default function Labels({
       {isArray(items) ? (
         items.map((label: string) => (
           <li key={`label-${label}`}>
-            <Link href={`${pathPrefix}/${label}`}>{formatLabel(label)}</Link>
+            <Link href={`${pathPrefix}/${label}`}>{formatLabel(label, dictionary)}</Link>
           </li>
         ))
       ) : (
@@ -35,7 +39,7 @@ export default function Labels({
                 href={`${pathPrefix}/${label}`}
                 className={getActiveClass(path, `^${pathPrefix}/${label}$`)}
               >
-                {formatLabel(label)} <span>{items[label]}</span>
+                {formatLabel(label, dictionary)} <span>{items[label]}</span>
               </Link>
             </li>
           ))}
@@ -45,6 +49,6 @@ export default function Labels({
   )
 }
 
-function formatLabel(string: string) {
-  return formatAsTitle(string.replace("-", " "))
+function formatLabel(string: string, dictionary: { _: string }) {
+  return dictionary[string] || formatAsTitle(string.replace("-", " "))
 }

--- a/data/books/2020-02-21-le-sens-de-ma-vie.md
+++ b/data/books/2020-02-21-le-sens-de-ma-vie.md
@@ -8,7 +8,7 @@ review_url: "https://goodreads.com/review/show/3198106981"
 bookshelves:
   - "french"
   - "non-fiction"
-  - "biography"
+  - "biographies"
 ---
 
 Je découvre Romain Gary à travers cet entretien autobiographique. Un tour d'horizon rapide et pour

--- a/data/books/2021-12-31-combats-et-metamorphoses-dune-femme.md
+++ b/data/books/2021-12-31-combats-et-metamorphoses-dune-femme.md
@@ -8,7 +8,7 @@ review_url: "https://goodreads.com/review/show/4426973088"
 bookshelves:
   - "french"
   - "non-fiction"
-  - "biography"
+  - "biographies"
   - "feminism"
   - "sociology"
 ---

--- a/data/labels.yml
+++ b/data/labels.yml
@@ -1,0 +1,2 @@
+bookshelves:
+  non-fiction: "Non-Fiction"

--- a/lib/books.ts
+++ b/lib/books.ts
@@ -6,6 +6,9 @@ import {
   sortItemsInAscendingOrder,
 } from 'lib/utils'
 
+import fs from 'fs'
+import YAML from 'yaml'
+
 export async function getSortedBooksData(limit?: number, bookshelf?: string) {
   const fileNames = getAllFileNamesForResource('books')
   const allBooksData = await Promise.all(fileNames.map(fileName => {
@@ -54,6 +57,12 @@ export function filterBooksByBookshelf(booksData: object[], bookshelfName: strin
   return booksData.filter((book) =>
     book["bookshelves"].includes(bookshelfName)
   )
+}
+
+export async function getBookshelvesDictionary() {
+  const labelsDictionary = fs.readFileSync('data/labels.yml', 'utf8')
+
+  return YAML.parse(labelsDictionary)["bookshelves"]
 }
 
 async function getBookshelvesData() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "remark": "^14.0.2",
         "remark-html": "^15.0.1",
         "sass": "^1.52.1",
-        "sharp": "^0.32.6"
+        "sharp": "^0.32.6",
+        "yaml": "^2.3.4"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.201",
@@ -5420,6 +5421,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yaml": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "remark": "^14.0.2",
     "remark-html": "^15.0.1",
     "sass": "^1.52.1",
-    "sharp": "^0.32.6"
+    "sharp": "^0.32.6",
+    "yaml": "^2.3.4"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.201",

--- a/pages/bookshelves.tsx
+++ b/pages/bookshelves.tsx
@@ -1,6 +1,6 @@
 import Labels from 'components/Labels'
 import Layout from 'components/Layout'
-import { getBookshelvesWithCount, getSortedBooksData } from 'lib/books'
+import { getBookshelvesDictionary, getBookshelvesWithCount, getSortedBooksData } from 'lib/books'
 
 import Image from 'next/image'
 import Link from 'next/link'
@@ -12,7 +12,8 @@ const title = 'Bookshelves'
 export default function Reads({
   allBooksData,
   allBooksYears,
-  allBookshelvesWithCount
+  allBookshelvesWithCount,
+  bookshelvesDictionary
 }: {
   allBooksData: {
     id: string
@@ -25,6 +26,9 @@ export default function Reads({
   allBookshelvesWithCount: {
     _: number
   }
+  bookshelvesDictionary: {
+    _: string
+  }
 }) {
   return (
     <Layout title={title}>
@@ -33,6 +37,7 @@ export default function Reads({
       <Labels
         items={allBookshelvesWithCount}
         pathPrefix="/bookshelves"
+        dictionary={bookshelvesDictionary}
       />
 
       {allBooksYears ? allBooksYears.map(year => (
@@ -80,12 +85,14 @@ export const getStaticProps: GetStaticProps = async () => {
   const allBooksData = await getSortedBooksData()
   const allBooksYears = isArray(allBooksData) ? null : Object.keys(allBooksData).sort().reverse()
   const allBookshelvesWithCount = await getBookshelvesWithCount()
+  const bookshelvesDictionary = await getBookshelvesDictionary()
 
   return {
     props: {
       allBooksData,
       allBooksYears,
-      allBookshelvesWithCount
+      allBookshelvesWithCount,
+      bookshelvesDictionary
     }
   }
 }

--- a/pages/bookshelves/[slug].tsx
+++ b/pages/bookshelves/[slug].tsx
@@ -1,6 +1,11 @@
 import Labels from 'components/Labels'
 import Layout from 'components/Layout'
-import { getAllBookshelfSlugs, getBookshelvesWithCount, getSortedBooksData } from 'lib/books'
+import {
+  getAllBookshelfSlugs,
+  getBookshelvesDictionary,
+  getBookshelvesWithCount,
+  getSortedBooksData
+} from 'lib/books'
 
 import Image from 'next/image'
 import Link from 'next/link'
@@ -11,7 +16,8 @@ export default function Reads({
   allBookshelvesWithCount,
   bookshelfData,
   bookshelfName,
-  bookshelfYears
+  bookshelfYears,
+  bookshelvesDictionary
 }: {
   allBookshelvesWithCount: {
     _: number
@@ -25,6 +31,9 @@ export default function Reads({
   }[]
   bookshelfName: string
   bookshelfYears?: string[]
+  bookshelvesDictionary: {
+    _: string
+  }
 }) {
   return (
     <Layout title={`Bookshelf: ${bookshelfName}`}>
@@ -33,6 +42,7 @@ export default function Reads({
       <Labels
         items={allBookshelvesWithCount}
         pathPrefix="/bookshelves"
+        dictionary={bookshelvesDictionary}
       />
 
       {bookshelfYears ? bookshelfYears.map(year => (
@@ -90,13 +100,15 @@ export const getStaticProps: GetStaticProps = async (context) => {
   const allBookshelvesWithCount = await getBookshelvesWithCount()
   const bookshelfData = await getSortedBooksData(null, bookshelfName)
   const bookshelfYears = isArray(bookshelfData) ? null : Object.keys(bookshelfData).sort().reverse()
+  const bookshelvesDictionary = await getBookshelvesDictionary()
 
   return {
     props: {
       allBookshelvesWithCount,
       bookshelfData,
       bookshelfName,
-      bookshelfYears
+      bookshelfYears,
+      bookshelvesDictionary
     }
   }
 }

--- a/pages/reads/[slug].tsx
+++ b/pages/reads/[slug].tsx
@@ -2,13 +2,14 @@ import Image from 'next/image'
 import DateRange from 'components/DateRange'
 import Labels from 'components/Labels'
 import Layout from 'components/Layout'
-import { getAllBookSlugs, getBookData } from 'lib/books'
+import { getAllBookSlugs, getBookData, getBookshelvesDictionary } from 'lib/books'
 
 import Link from 'next/link'
 import { GetStaticPaths, GetStaticProps } from 'next'
 
 export default function Book({
-  bookData
+  bookData,
+  bookshelvesDictionary
 }: {
   bookData: {
     image: string
@@ -20,6 +21,9 @@ export default function Book({
     reviewUrl: string
     bookshelves: [string]
     content: string
+  }
+  bookshelvesDictionary: {
+    _: string
   }
 }) {
   return (
@@ -41,6 +45,7 @@ export default function Book({
           <Labels
             items={bookData.bookshelves}
             pathPrefix="/bookshelves"
+            dictionary={bookshelvesDictionary}
           />
 
           <Link className="book-date" href={bookData.reviewUrl}>
@@ -71,10 +76,12 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const bookData = await getBookData(params.slug as string)
+  const bookshelvesDictionary = await getBookshelvesDictionary()
 
   return {
     props: {
-      bookData
+      bookData,
+      bookshelvesDictionary
     }
   }
 }


### PR DESCRIPTION
For some labels, such as "non-fiction", I want to keep the hyphen from
the slug when displaying it in the UI. This introduces a dictionary for
bookshelf names and updates the code so that it checks it for a given
slug, before falling back to formatting it as a title.